### PR TITLE
Refactoring and updated the configuration due to the new version of t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ Look though the configs:
     
     jdbc:
       mysql:
-        url: jdbc:mysql://localhost:3306/cayenne?connectTimeout=0&autoReconnect=true
+        jdbcUrl: jdbc:mysql://localhost:3306/cayenne?connectTimeout=0&autoReconnect=true
         driverClassName: com.mysql.jdbc.Driver
-        initialSize: 1
+        maximumPoolSize: 1
+        minimumIdle: 1
         username: root
         password:
     
@@ -67,9 +68,10 @@ To escape MySQL database stuff overwrite *config.yml* for Derby db:
 
     jdbc:
       derby:
-        url: jdbc:derby:target/demodb;create=true
+        jdbcUrl: jdbc:derby:target/demodb;create=true
         driverClassName: org.apache.derby.jdbc.EmbeddedDriver
-        initialSize: 1
+        maximumPoolSize: 1
+        minimumIdle: 1
     
     cayenne:
       datasource: derby

--- a/config.yml
+++ b/config.yml
@@ -1,8 +1,9 @@
 jdbc:
   mysql:
-    url: jdbc:mysql://localhost:3306/cayenne?connectTimeout=0&autoReconnect=true
+    jdbcUrl: jdbc:mysql://localhost:3306/cayenne?connectTimeout=0&autoReconnect=true
     driverClassName: com.mysql.jdbc.Driver
-    initialSize: 1
+    maximumPoolSize: 1
+    minimumIdle: 1
     username: root
     password:
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             <dependency>
                 <groupId>io.bootique.bom</groupId>
                 <artifactId>bootique-bom</artifactId>
-                <version>0.22</version>
+                <version>0.25</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>io.bootique.jdbc</groupId>
-            <artifactId>bootique-jdbc</artifactId>
+            <artifactId>bootique-jdbc-hikaricp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.bootique.logback</groupId>

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -11,7 +11,7 @@ import org.apache.cayenne.configuration.server.ServerModule;
 
 public class Application implements Module {
     public static final void main(String[] args) {
-        Bootique.app(args).module(Application.class).autoLoadModules().run();
+        Bootique.app(args).module(Application.class).autoLoadModules().exec().exit();
     }
 
     @Override


### PR DESCRIPTION
…he bootique library.

Hi! The old example generated an error with the new library 0.25: - Error running command '--config=config.yml': No concrete 'bootique-jdbc' implementation found. You will need to add one (such as 'bootique-jdbc-tomcat', etc.) as an application dependency. Also replaced is the method, designated as "Deprecated"
